### PR TITLE
Added flag to enforce HARDWARE_BACKED evaluationType during verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ try {
         Config::VERIFIER_CERTIFICATE_DIGEST_SHA256 => ['SHA-256-FINGERPRINT'],
         Config::VERIFIER_PACKAGE_NAME => ['APK-NAME-FOR-TEST'],
         Config::VERIFIER_API_KEY => 'GOOGLE-API-KEY',
+        Config::VERIFIER_HARDWARE_BACKED => true,
     ]);
 
     $attestation = new Attestation($attestationConfig);
@@ -75,6 +76,7 @@ try {
         Config::VERIFIER_TIMESTAMP_DIFF => 10 * 60 * 1000,
         Config::VERIFIER_CERTIFICATE_DIGEST_SHA256 => ['SHA-256-FINGERPRINT'],
         Config::VERIFIER_PACKAGE_NAME => ['APK-NAME-FOR-TEST'],
+        Config::VERIFIER_HARDWARE_BACKED => true,
     ]);
 
     $attestation = new Attestation($attestationConfig);

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -11,12 +11,14 @@ class Config
     const VERIFIER_CERTIFICATE_DIGEST_SHA256 = 'apkCertificateDigestSha256';
     const VERIFIER_PACKAGE_NAME = 'apkPackageName';
     const VERIFIER_API_KEY = 'apiKey';
+    const VERIFIER_HARDWARE_BACKED = 'hardwareBacked';
 
     private VerifierType $verifierType;
     private int $timestampDiffMS = 10 * 60 * 60 * 1000;
     private array $apkCertificateDigestSha256 = [];
     private array $apkPackageName = [];
     private string $apiKey;
+    private bool $hardwareBacked = false;
 
     public function __construct(array $configOptions)
     {
@@ -63,4 +65,11 @@ class Config
     {
         return $this->apiKey;
     }
+
+    public function getHardwareBacked(): bool
+    {
+        return $this->hardwareBacked;
+    }
+
+
 }

--- a/src/Statement/StatementBody.php
+++ b/src/Statement/StatementBody.php
@@ -13,6 +13,7 @@ class StatementBody
     private bool $ctsProfileMatch;
     private array $apkCertificateDigestSha256;
     private bool $basicIntegrity;
+    private string $evaluationType;
 
     public function __construct(array $body)
     {
@@ -66,5 +67,10 @@ class StatementBody
     public function getApkCertificateDigestSha256(): array
     {
         return $this->apkCertificateDigestSha256;
+    }
+
+    public function getEvaluationType(): string
+    {
+        return $this->evaluationType;
     }
 }

--- a/src/Verifier/Verifier.php
+++ b/src/Verifier/Verifier.php
@@ -72,7 +72,8 @@ abstract class Verifier
             && $this->guardDeviceIsNotRooted($body)
             && $this->guardTimestamp($body)
             && $this->guardApkCertificateDigestSha256($body)
-            && $this->guardApkPackageName($body);
+            && $this->guardApkPackageName($body)
+            && $this->guardHardwareBacked($body);
     }
 
     private function guardNonce(Nonce $nonce, StatementBody $statementBody): bool
@@ -151,5 +152,11 @@ abstract class Verifier
         }
 
         return true;
+    }
+
+    private function guardHardwareBacked(StatementBody $statementBody): bool
+    {
+        return !$this->config->getHardwareBacked()
+            || in_array('HARDWARE_BACKED',explode(',',$statementBody->getEvaluationType()),true)!==false;
     }
 }


### PR DESCRIPTION
Added flag to the Config, Verifier, and StatementBody allowing to indicate an evaluationType node check requiring the HARDWARE_BACKED flag to be set within the SafetyNet attestation.